### PR TITLE
Fix add dataset disposal handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,15 @@ We really like people helping us with the project. Nevertheless, take your time 
 
 ## Changelog
 
-<details open="open"><summary>v0.8.7</summary>
+<details open="open"><summary>v0.8.8</summary>
+
+>- Dataset interop calls are ignored safely when the target chart was already disposed.
+>- Reduced allocation and lookup work while resolving and disposing Chart.js instances.
+>- Refactored library and sample code for .NET 11 analyzer/style guidance.
+
+</details>
+
+<details><summary>v0.8.7</summary>
 
 >- Hardened chart initialization to better handle rapid reinitialization and existing Chart.js instances for the same canvas.
 >- Resize events now include browser viewport dimensions via `WindowWidth` and `WindowHeight`.

--- a/src/pax.BlazorChartJs.samplelib/BarChartComp.razor
+++ b/src/pax.BlazorChartJs.samplelib/BarChartComp.razor
@@ -43,11 +43,3 @@
         <img id="chartImage" src="@imageString" alt="chart" />
     }
 </div>
-<div>
-    @if (canvasInfo != null)
-    {
-        <img id="canvasImage" src="@canvasInfo" alt="chart" />
-    }
-</div>
-
-

--- a/src/pax.BlazorChartJs.samplelib/BarChartComp.razor.cs
+++ b/src/pax.BlazorChartJs.samplelib/BarChartComp.razor.cs
@@ -9,7 +9,6 @@ public partial class BarChartComp : ComponentBase
     IconsChartJsConfig chartJsConfig = null!;
     private string? labelClicked;
     private string? imageString;
-    private string? canvasInfo;
     private Lazy<Task<IJSObjectReference>> moduleTask = null!;
     private string chartVersion = "unknown";
 
@@ -23,12 +22,10 @@ public partial class BarChartComp : ComponentBase
             Type = ChartType.bar,
             Data = new ChartJsData()
             {
-                Labels = new List<string>()
-                {
+                Labels = [
                     "Red", "Blue", "Yellow", "Green", "Purple", "Orange"
-                },
-                Datasets = new List<ChartJsDataset>()
-                {
+                ],
+                Datasets = [
                     new BarDataset()
                     {
                         Label = "# of Votes",
@@ -51,7 +48,7 @@ public partial class BarChartComp : ComponentBase
                         ],
                         BorderWidth = 1
                     }
-                }
+                ]
             },
             Options = new()
             {
@@ -107,7 +104,7 @@ public partial class BarChartComp : ComponentBase
 
     private void ChartEventTriggered(ChartJsEvent chartJsEvent)
     {
-        if (chartJsEvent is ChartJsInitEvent initEvent)
+        if (chartJsEvent is ChartJsInitEvent)
         {
             SetChartVersion();
         }
@@ -121,7 +118,7 @@ public partial class BarChartComp : ComponentBase
     private async void SetChartVersion()
     {
         chartVersion = await jsRuntime.InvokeAsync<string>("getChartVersion");
-        await InvokeAsync(() => StateHasChanged());
+        await InvokeAsync(StateHasChanged);
     }
 
     private async Task MakeImage()
@@ -129,7 +126,7 @@ public partial class BarChartComp : ComponentBase
         if (chartComponent != null)
         {
             imageString = await chartComponent.GetChartImage();
-            await InvokeAsync(() => StateHasChanged());
+            await InvokeAsync(StateHasChanged);
         }
     }
 
@@ -149,8 +146,8 @@ public partial class BarChartComp : ComponentBase
             chartJsConfig.Options.Plugins = new();
         }
 
-        List<ChartIconsConfig> icons = new()
-        {
+        List<ChartIconsConfig> icons =
+        [
             new()
             {
                 XWidth = 30,
@@ -175,7 +172,7 @@ public partial class BarChartComp : ComponentBase
                 ImageSrc = "_content/pax.BlazorChartJs.samplelib/images/artanis-min.png",
                 Cmdr = "artanis"
             },
-        };
+        ];
 
         chartJsConfig.Options.Plugins.BarIcons = icons;
 
@@ -209,22 +206,11 @@ public partial class BarChartComp : ComponentBase
         chartJsConfig.ReinitializeChart();
     }
 
-    private async Task GetCanvasInfo()
-    {
-        if (moduleTask != null)
-        {
-            var module = await moduleTask.Value.ConfigureAwait(false);
-            canvasInfo = await module.InvokeAsync<string>("getCanvasInfo", chartJsConfig.ChartJsConfigGuid)
-                .ConfigureAwait(false);
-            await InvokeAsync(() => StateHasChanged());
-        }
-    }
-
     private void AddData()
     {
         var dataAddEventArgs = ChartUtils.GetRandomData(chartJsConfig.Data.Datasets.Count);
 
-        Dictionary<ChartJsDataset, AddDataObject> datas = new();
+        Dictionary<ChartJsDataset, AddDataObject> datas = [];
         for (int i = 0; i < chartJsConfig.Data.Datasets.Count; i++)
         {
             ChartJsDataset dataset = chartJsConfig.Data.Datasets[i];
@@ -242,7 +228,7 @@ public partial class BarChartComp : ComponentBase
         var data = ChartUtils.GetRandomData(chartJsConfig.Data.Datasets.Count,
          chartJsConfig.Data.Labels.Count, -100, 100);
 
-        Dictionary<ChartJsDataset, SetDataObject> chartData = new();
+        Dictionary<ChartJsDataset, SetDataObject> chartData = [];
 
         for (int i = 0; i < chartJsConfig.Data.Datasets.Count; i++)
         {

--- a/src/pax.BlazorChartJs.samplelib/CustomChartComp.razor
+++ b/src/pax.BlazorChartJs.samplelib/CustomChartComp.razor
@@ -132,15 +132,6 @@
         chartJsConfig.RemoveData();
     }
 
-    public void Dispose()
-    {
-        if (moduleTask != null && moduleTask.IsValueCreated)
-        {
-            var module = moduleTask.Value.GetAwaiter().GetResult();
-            module.DisposeAsync();
-        }
-    }
-
     public async ValueTask DisposeAsync()
     {
         await DisposeAsyncCore();

--- a/src/pax.BlazorChartJs.samplelib/CustomPluginComp.razor
+++ b/src/pax.BlazorChartJs.samplelib/CustomPluginComp.razor
@@ -1,7 +1,7 @@
 ﻿@using Microsoft.JSInterop
 @using pax.BlazorChartJs
 @using System.Text.Json
-@implements IDisposable
+@implements IAsyncDisposable
 
 @inject IJSRuntime jsRuntime
 
@@ -150,12 +150,12 @@
 
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         if (moduleTask != null && moduleTask.IsValueCreated)
         {
-            var module = moduleTask.Value.GetAwaiter().GetResult();
-            module.DisposeAsync();
+            var module = await moduleTask.Value.ConfigureAwait(false);
+            await module.DisposeAsync().ConfigureAwait(false);
         }
     }
 }

--- a/src/pax.BlazorChartJs.samplelib/DataLabelsPerDatasetChartComp.razor
+++ b/src/pax.BlazorChartJs.samplelib/DataLabelsPerDatasetChartComp.razor
@@ -133,7 +133,7 @@
     private async void SetChartVersion()
     {
         chartVersion = await jsRuntime.InvokeAsync<string>("getChartVersion");
-        await InvokeAsync(() => StateHasChanged());
+        await InvokeAsync(StateHasChanged);
     }
 
     private void ShowDataLabels()

--- a/src/pax.BlazorChartJs.samplelib/EventcallbackChartComp.razor
+++ b/src/pax.BlazorChartJs.samplelib/EventcallbackChartComp.razor
@@ -2,7 +2,7 @@
 @using Microsoft.JSInterop
 
 @inject IJSRuntime jsRuntime
-@implements IDisposable
+@implements IAsyncDisposable
 
 <div class="btn-group">
     <button type="button" class="btn btn-primary" @onclick="Randomize">Randomize</button>
@@ -96,12 +96,12 @@
         chartJsConfig.SetData(chartData);
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         if (moduleTask is not null && moduleTask.IsValueCreated)
         {
-            var module = moduleTask.Value.GetAwaiter().GetResult();
-            module.DisposeAsync();
+            var module = await moduleTask.Value.ConfigureAwait(false);
+            await module.DisposeAsync().ConfigureAwait(false);
         }
     }
 }

--- a/src/pax.BlazorChartJs.samplelib/HtmlLegendChartComp.razor.cs
+++ b/src/pax.BlazorChartJs.samplelib/HtmlLegendChartComp.razor.cs
@@ -69,16 +69,16 @@ public partial class HtmlLegendChartComp : ComponentBase
         base.OnInitialized();
     }
 
-    private void ChartEventTriggered(ChartJsEvent chartJsEvent)
+    private async Task ChartEventTriggered(ChartJsEvent chartJsEvent)
     {
         if (chartJsEvent is ChartJsInitEvent)
         {
-            InvokeAsync(StateHasChanged).Wait();
-            UpdateLegend();
+            await InvokeAsync(StateHasChanged).ConfigureAwait(false);
+            await UpdateLegend().ConfigureAwait(false);
         }
         else if (chartJsEvent is ChartJsAnimationCompleteEvent)
         {
-            // UpdateLegend();
+            // await UpdateLegend().ConfigureAwait(false);
         }
         else if (chartJsEvent is ChartJsLabelHoverEvent labelHoverEvent)
         {
@@ -86,9 +86,12 @@ public partial class HtmlLegendChartComp : ComponentBase
         }
     }
 
-    public void UpdateLegend()
+    public async Task UpdateLegend()
     {
-        _ = legendComponent?.UpdateLegend();
+        if (legendComponent != null)
+        {
+            await legendComponent.UpdateLegend().ConfigureAwait(false);
+        }
     }
 
     private void Randomize()
@@ -106,7 +109,7 @@ public partial class HtmlLegendChartComp : ComponentBase
         chartJsConfig.SetData(chartData);
     }
 
-    private void AddDataset()
+    private async Task AddDataset()
     {
         var dataset = ChartUtils.GetRandomDataset(chartJsConfig.Type == null ? ChartType.bar : chartJsConfig.Type.Value, chartJsConfig.Data.Datasets.Count + 1, chartJsConfig.Data.Labels.Count);
         if (dataset is LineDataset lineDataset)
@@ -118,15 +121,15 @@ public partial class HtmlLegendChartComp : ComponentBase
             lineDataset.PointHoverBorderWidth = 10;
         }
         chartJsConfig.AddDataset(dataset);
-        UpdateLegend();
+        await UpdateLegend().ConfigureAwait(false);
     }
 
-    private void RemoveLastDataset()
+    private async Task RemoveLastDataset()
     {
         if (chartJsConfig.Data.Datasets.Count > 0)
         {
             chartJsConfig.RemoveDataset(chartJsConfig.Data.Datasets.Last());
-            UpdateLegend();
+            await UpdateLegend().ConfigureAwait(false);
         }
     }
 }

--- a/src/pax.BlazorChartJs.samplelib/HtmlLegendChartComp.razor.cs
+++ b/src/pax.BlazorChartJs.samplelib/HtmlLegendChartComp.razor.cs
@@ -15,16 +15,14 @@ public partial class HtmlLegendChartComp : ComponentBase
             Type = ChartType.line,
             Data = new ChartJsData()
             {
-                Labels = new List<string>()
-                {
+                Labels = [
                     "Red", "Blue", "Yellow", "Green", "Purple", "Orange"
-                },
-                Datasets = new List<ChartJsDataset>()
-                {
+                ],
+                Datasets = [
                     new LineDataset()
                     {
                         Label = "Team 1",
-                        Data = new List<object>() { 1, 2, 3, 4, 5, 6 },
+                        Data = [ 1, 2, 3, 4, 5, 6 ],
                         BackgroundColor = "lightblue",
                         BorderColor = "blue",
                         BorderWidth = 5,
@@ -37,7 +35,7 @@ public partial class HtmlLegendChartComp : ComponentBase
                     new LineDataset()
                     {
                         Label = "Team 2",
-                        Data = new List<object>() { 6, 5, 4, 3, 2, 1 },
+                        Data = [ 6, 5, 4, 3, 2, 1 ],
                         BackgroundColor = "lightgreen",
                         BorderColor = "green",
                         BorderWidth = 5,
@@ -47,7 +45,7 @@ public partial class HtmlLegendChartComp : ComponentBase
                         PointHoverRadius = 10,
                         PointHoverBorderWidth = 10,
                     }
-                }
+                ]
             },
             Options = new ChartJsOptions()
             {
@@ -55,7 +53,7 @@ public partial class HtmlLegendChartComp : ComponentBase
                 OnHoverEvent = true,
                 Plugins = new Plugins()
                 {
-                    ArbitraryLines = new List<ArbitraryLineConfig>(),
+                    ArbitraryLines = [],
                     Legend = new Legend()
                     {
                         Display = false
@@ -75,7 +73,7 @@ public partial class HtmlLegendChartComp : ComponentBase
     {
         if (chartJsEvent is ChartJsInitEvent)
         {
-            InvokeAsync(() => StateHasChanged()).Wait();
+            InvokeAsync(StateHasChanged).Wait();
             UpdateLegend();
         }
         else if (chartJsEvent is ChartJsAnimationCompleteEvent)
@@ -90,14 +88,14 @@ public partial class HtmlLegendChartComp : ComponentBase
 
     public void UpdateLegend()
     {
-        legendComponent?.UpdateLegend();
+        _ = legendComponent?.UpdateLegend();
     }
 
     private void Randomize()
     {
         var data = ChartUtils.GetRandomData(chartJsConfig.Data.Datasets.Count, chartJsConfig.Data.Labels.Count, -100, 100);
 
-        Dictionary<ChartJsDataset, SetDataObject> chartData = new();
+        Dictionary<ChartJsDataset, SetDataObject> chartData = [];
 
         for (int i = 0; i < chartJsConfig.Data.Datasets.Count; i++)
         {

--- a/src/pax.BlazorChartJs.samplelib/HtmlLegendPieChartComp.razor
+++ b/src/pax.BlazorChartJs.samplelib/HtmlLegendPieChartComp.razor
@@ -78,12 +78,15 @@
         base.OnInitialized();
     }
 
-    public void ChartEventTriggered(ChartJsEvent chartJsEvent)
+    public async Task ChartEventTriggered(ChartJsEvent chartJsEvent)
     {
         if (chartJsEvent is ChartJsInitEvent initEvent)
         {
-            InvokeAsync(StateHasChanged).Wait();
-            pieLegendComponent?.UpdateLegend();
+            await InvokeAsync(StateHasChanged).ConfigureAwait(false);
+            if (pieLegendComponent != null)
+            {
+                await pieLegendComponent.UpdateLegend().ConfigureAwait(false);
+            }
         }
     }
 
@@ -108,16 +111,22 @@
         chartJsConfig.SetData(chartData);
     }
 
-    private void AddData()
+    private async Task AddData()
     {
         var dataAddEventArgs = ChartUtils.GetRandomData(chartJsConfig.Data.Datasets.Count);
         chartJsConfig.AddData(dataAddEventArgs.Label, dataAddEventArgs.Data);
-        pieLegendComponent?.UpdateLegend();
+        if (pieLegendComponent != null)
+        {
+            await pieLegendComponent.UpdateLegend().ConfigureAwait(false);
+        }
     }
 
-    private void RemoveLastDataFromDatasets()
+    private async Task RemoveLastDataFromDatasets()
     {
         chartJsConfig.RemoveData();
-        pieLegendComponent?.UpdateLegend();
+        if (pieLegendComponent != null)
+        {
+            await pieLegendComponent.UpdateLegend().ConfigureAwait(false);
+        }
     }
 }

--- a/src/pax.BlazorChartJs.samplelib/HtmlLegendPieChartComp.razor
+++ b/src/pax.BlazorChartJs.samplelib/HtmlLegendPieChartComp.razor
@@ -82,7 +82,7 @@
     {
         if (chartJsEvent is ChartJsInitEvent initEvent)
         {
-            InvokeAsync(() => StateHasChanged()).Wait();
+            InvokeAsync(StateHasChanged).Wait();
             pieLegendComponent?.UpdateLegend();
         }
     }

--- a/src/pax.BlazorChartJs.samplelib/LineChartComp.razor
+++ b/src/pax.BlazorChartJs.samplelib/LineChartComp.razor
@@ -15,5 +15,5 @@
 </div>
 
 <div class="chart-container w-75">
-    <ChartComponent @ref="chartComponent" ChartJsConfig="chartJsConfig"></ChartComponent>
+    <ChartComponent ChartJsConfig="chartJsConfig"></ChartComponent>
 </div>

--- a/src/pax.BlazorChartJs.samplelib/LineChartComp.razor.cs
+++ b/src/pax.BlazorChartJs.samplelib/LineChartComp.razor.cs
@@ -4,8 +4,6 @@ namespace pax.BlazorChartJs.samplelib;
 
 public partial class LineChartComp : ComponentBase
 {
-
-    ChartComponent? chartComponent;
     ChartJsConfig chartJsConfig = null!;
 
     protected override void OnInitialized()
@@ -15,16 +13,14 @@ public partial class LineChartComp : ComponentBase
             Type = ChartType.line,
             Data = new ChartJsData()
             {
-                Labels = new List<string>()
-                {
+                Labels = [
                     "Red", "Blue", "Yellow", "Green", "Purple", "Orange"
-                },
-                Datasets = new List<ChartJsDataset>()
-                {
+                ],
+                Datasets = [
                     new LineDataset()
                     {
                         Label = "Team 1",
-                        Data = new List<object>() { 1, 2, 3, 4, 5, 6 },
+                        Data = [ 1, 2, 3, 4, 5, 6 ],
                         BackgroundColor = "lightblue",
                         BorderColor = "lightblue",
                         BorderWidth = 5,
@@ -39,7 +35,7 @@ public partial class LineChartComp : ComponentBase
                     new LineDataset()
                     {
                         Label = "Team 2",
-                        Data = new List<object>() { 6, 5, 4, 3, 2, 1 },
+                        Data = [ 6, 5, 4, 3, 2, 1 ],
                         BackgroundColor = "lightgreen",
                         BorderColor = "lightgreen",
                         BorderWidth = 5,
@@ -51,14 +47,14 @@ public partial class LineChartComp : ComponentBase
                         PointHitRadius = 6,
                         Tension = 0
                     }
-                }
+                ]
             },
             Options = new ChartJsOptions()
             {
                 Responsive = true,
                 Plugins = new Plugins()
                 {
-                    ArbitraryLines = new List<ArbitraryLineConfig>()
+                    ArbitraryLines = []
                 },
                 Scales = new ChartJsOptionsScales()
                 {
@@ -70,7 +66,7 @@ public partial class LineChartComp : ComponentBase
                         Title = new Title()
                         {
                             Display = true,
-                            Text = new IndexableOption<string>("GameTime"),
+                            Text = "GameTime",
                             Color = "black",
                             Font = new()
                             {
@@ -183,8 +179,7 @@ public partial class LineChartComp : ComponentBase
             chartJsConfig.Options.Plugins = new();
         }
 
-        chartJsConfig.Options.Plugins.ArbitraryLines = new List<ArbitraryLineConfig>()
-        {
+        chartJsConfig.Options.Plugins.ArbitraryLines = [
             new ArbitraryLineConfig()
             {
                 ArbitraryLineColor = "blue",
@@ -192,7 +187,8 @@ public partial class LineChartComp : ComponentBase
                 XWidth = 3,
                 Text = "Plugin Test"
             }
-        };
+        ];
+
         chartJsConfig.UpdateChartOptions();
     }
 
@@ -201,7 +197,7 @@ public partial class LineChartComp : ComponentBase
         var dataAddEventArgs = ChartUtils.GetRandomData(chartJsConfig.Data.Datasets.Count);
         // chartJsConfig.AddData(dataAddEventArgs.Label, dataAddEventArgs.Data);
 
-        Dictionary<ChartJsDataset, AddDataObject> data = new Dictionary<ChartJsDataset, AddDataObject>();
+        Dictionary<ChartJsDataset, AddDataObject> data = [];
         for (int i = 0; i < chartJsConfig.Data.Datasets.Count; i++)
         {
             ChartJsDataset dataset = chartJsConfig.Data.Datasets[i];
@@ -215,7 +211,7 @@ public partial class LineChartComp : ComponentBase
     {
         var data = ChartUtils.GetRandomData(chartJsConfig.Data.Datasets.Count, chartJsConfig.Data.Labels.Count, -100, 100);
 
-        Dictionary<ChartJsDataset, SetDataObject> chartData = new();
+        Dictionary<ChartJsDataset, SetDataObject> chartData = [];
 
         for (int i = 0; i < chartJsConfig.Data.Datasets.Count; i++)
         {

--- a/src/pax.BlazorChartJs.samplelib/PreloadPluginChart.razor
+++ b/src/pax.BlazorChartJs.samplelib/PreloadPluginChart.razor
@@ -31,7 +31,7 @@
             var chartModule = await chartJsModuleTask.Value;
             var pluginModule = await pluginModuleTask.Value;
             ChartConfig = GetChartConfig();
-            await InvokeAsync(() => StateHasChanged());
+            await InvokeAsync(StateHasChanged);
         }
         await base.OnAfterRenderAsync(firstRender);
     }

--- a/src/pax.BlazorChartJs.samplelib/PreloadPluginChart.razor
+++ b/src/pax.BlazorChartJs.samplelib/PreloadPluginChart.razor
@@ -97,12 +97,18 @@
         if (chartJsModuleTask.IsValueCreated)
         {
             var module = await chartJsModuleTask.Value;
-            module?.DisposeAsync();
+            if (module != null)
+            {
+                await module.DisposeAsync();
+            }
         }
         if (pluginModuleTask.IsValueCreated)
         {
             var module = await pluginModuleTask.Value;
-            module?.DisposeAsync();
+            if (module != null)
+            {
+                await module.DisposeAsync();
+            }
         }
     }
 }

--- a/src/pax.BlazorChartJs.samplelib/SourceCodeComponent.razor
+++ b/src/pax.BlazorChartJs.samplelib/SourceCodeComponent.razor
@@ -52,11 +52,11 @@
     private async Task LoadData()
     {
         isLoading = true;
-        await InvokeAsync(() => StateHasChanged());
+        await InvokeAsync(StateHasChanged);
         razor = await GetMarkdownString(Options.RawRazorUrl, "razor");
         cs = await GetMarkdownString(Options.RawCsUrl, "csharp");
         isLoading = false;
-        await InvokeAsync(() => StateHasChanged());
+        await InvokeAsync(StateHasChanged);
         dataReady = true;
         HighlightCode();
     }

--- a/src/pax.BlazorChartJs.samplelib/TestChartComp.razor
+++ b/src/pax.BlazorChartJs.samplelib/TestChartComp.razor
@@ -204,6 +204,6 @@
     {
         var task = chartComponent?.GetDataVisibility(0);
         isVisible = await task.GetValueOrDefault();
-        await InvokeAsync(() => StateHasChanged());
+        await InvokeAsync(StateHasChanged);
     }
 }

--- a/src/pax.BlazorChartJs.samplelib/TimesChartComp.razor
+++ b/src/pax.BlazorChartJs.samplelib/TimesChartComp.razor
@@ -3,7 +3,7 @@
 @using Microsoft.JSInterop
 
 @inject IJSRuntime jsRuntime
-@implements IDisposable
+@implements IAsyncDisposable
 
 <h3>TimeChart</h3>
 
@@ -144,14 +144,20 @@
         }
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
-        if (moduleTask != null && moduleTask.IsValueCreated)
+        try
         {
-            var module = moduleTask.Value.GetAwaiter().GetResult();
-            module.DisposeAsync();
+            if (moduleTask != null && moduleTask.IsValueCreated)
+            {
+                var module = await moduleTask.Value.ConfigureAwait(false);
+                await module.DisposeAsync().ConfigureAwait(false);
+            }
         }
-        editContext.OnFieldChanged -= FieldChanged;
+        finally
+        {
+            editContext.OnFieldChanged -= FieldChanged;
+        }
     }
 
     public record TimeOptions

--- a/src/pax.BlazorChartJs.samplelib/pax.BlazorChartJs.samplelib.csproj
+++ b/src/pax.BlazorChartJs.samplelib/pax.BlazorChartJs.samplelib.csproj
@@ -16,7 +16,7 @@
     <LangVersion>latest</LangVersion>
     <WarningsNotAsErrors>CA5394</WarningsNotAsErrors>
     <DisabledWarnings>1591</DisabledWarnings>
-    <NoWarn>1591, CA5394, CA2007, CA1034, CA2227</NoWarn>	
+    <NoWarn>1591, CA5394, CA2007, CA1034, CA2227, IDE0160, IDE0040, IDE0008</NoWarn>	
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/pax.BlazorChartJs/BlazorLegend/LegendComponentBase.cs
+++ b/src/pax.BlazorChartJs/BlazorLegend/LegendComponentBase.cs
@@ -28,7 +28,7 @@ public class LegendComponentBase : ComponentBase
 
         LegendItems = await ChartComponent.GetLegendItems()
             .ConfigureAwait(false);
-        await InvokeAsync(() => StateHasChanged())
+        await InvokeAsync(StateHasChanged)
             .ConfigureAwait(false);
     }
 
@@ -41,7 +41,7 @@ public class LegendComponentBase : ComponentBase
 
         ArgumentNullException.ThrowIfNull(item);
 
-        if (ChartJsConfig.Type == ChartType.pie || ChartJsConfig.Type == ChartType.doughnut)
+        if (ChartJsConfig.Type is ChartType.pie or ChartType.doughnut)
         {
             await ChartComponent.ToggleDataVisibility(item.Index)
                 .ConfigureAwait(false);
@@ -58,7 +58,8 @@ public class LegendComponentBase : ComponentBase
 
             item.Hidden = isVisible;
         }
-        await InvokeAsync(() => StateHasChanged())
+
+        await InvokeAsync(StateHasChanged)
             .ConfigureAwait(false);
     }
 
@@ -82,7 +83,7 @@ public class LegendComponentBase : ComponentBase
         await ChartComponent.SetDatasetPointsActive(item.DatasetIndex)
             .ConfigureAwait(false);
 
-        await InvokeAsync(() => StateHasChanged())
+        await InvokeAsync(StateHasChanged)
             .ConfigureAwait(false);
     }
 
@@ -105,19 +106,12 @@ public class LegendComponentBase : ComponentBase
 
         HoverItemIndex = null;
 
-        await InvokeAsync(() => StateHasChanged())
+        await InvokeAsync(StateHasChanged)
             .ConfigureAwait(false);
     }
 
     private int GetItemIndex(ChartJsLegendItem item)
     {
-        if (ChartJsConfig.Type == ChartType.pie || ChartJsConfig.Type == ChartType.doughnut)
-        {
-            return item.Index;
-        }
-        else
-        {
-            return item.DatasetIndex;
-        }
+        return ChartJsConfig.Type is ChartType.pie or ChartType.doughnut ? item.Index : item.DatasetIndex;
     }
 }

--- a/src/pax.BlazorChartJs/ChartComponent.razor.cs
+++ b/src/pax.BlazorChartJs/ChartComponent.razor.cs
@@ -62,89 +62,98 @@ public partial class ChartComponent : ComponentBase, IAsyncDisposable
 
     private async void ChartJsConfig_ChartRedraw(object? sender, EventArgs e)
     {
-        try
+        await InvokeChartInteropAsync(async () =>
         {
-            if (dotNetHelper != null)
+            if (dotNetHelper == null)
             {
-                var initResult = await ChartJsInterop.InitChart(ChartJsConfig, dotNetHelper).ConfigureAwait(false);
-                if (initResult.Success == true)
-                {
-                    await InvokeAsync(() =>
-                        OnEventTriggered.InvokeAsync(new ChartJsInitEvent()
-                        {
-                            ChartJsConfigGuid = ChartJsConfig.ChartJsConfigGuid,
-                            Height = initResult.Height,
-                            Width = initResult.Width,
-                            WindowHeight = initResult.WindowHeight,
-                            WindowWidth = initResult.WindowWidth
-                        }))
-                    .ConfigureAwait(false);
-                }
+                return;
             }
-        }
-        catch (ObjectDisposedException) { }
-        catch (OperationCanceledException) { }
+
+            var initResult = await ChartJsInterop.InitChart(ChartJsConfig, dotNetHelper).ConfigureAwait(false);
+            if (initResult.Success == true)
+            {
+                await InvokeAsync(() =>
+                    OnEventTriggered.InvokeAsync(new ChartJsInitEvent()
+                    {
+                        ChartJsConfigGuid = ChartJsConfig.ChartJsConfigGuid,
+                        Height = initResult.Height,
+                        Width = initResult.Width,
+                        WindowHeight = initResult.WindowHeight,
+                        WindowWidth = initResult.WindowWidth
+                    }))
+                .ConfigureAwait(false);
+            }
+        }).ConfigureAwait(false);
     }
 
     private async void ChartJsConfig_ChartOptionsUpdate(object? sender, EventArgs e)
     {
-        if (dotNetHelper != null)
+        await InvokeChartInteropAsync(async () =>
         {
-            await ChartJsInterop.UpdateChartOptions(ChartJsConfig, dotNetHelper).ConfigureAwait(false);
-        }
+            if (dotNetHelper != null)
+            {
+                await ChartJsInterop.UpdateChartOptions(ChartJsConfig, dotNetHelper).ConfigureAwait(false);
+            }
+        }).ConfigureAwait(false);
     }
 
     private async void ChartJsConfig_DatasetsSet(object? sender, DatasetsSetEventArgs e)
     {
-        await ChartJsInterop.SetDatasets(ChartJsConfig.ChartJsConfigGuid, e.Datasets).ConfigureAwait(false);
+        await InvokeChartInteropAsync(() => ChartJsInterop.SetDatasets(ChartJsConfig.ChartJsConfigGuid, e.Datasets))
+            .ConfigureAwait(false);
     }
 
     private async void ChartJsConfig_DatasetsUpdate(object? sender, DatasetsUpdateEventArgs e)
     {
-        await ChartJsInterop.UpdateDatasets(ChartJsConfig.ChartJsConfigGuid, e.Datasets, e.Smooth)
+        await InvokeChartInteropAsync(() => ChartJsInterop.UpdateDatasets(ChartJsConfig.ChartJsConfigGuid, e.Datasets, e.Smooth))
             .ConfigureAwait(false);
     }
 
     private async void ChartJsConfig_AddDataEvent(object? sender, AddDataEventArgs e)
     {
-        await ChartJsInterop.AddData(ChartJsConfig.ChartJsConfigGuid, e.Label, e.AtPosition, e.Datas)
+        await InvokeChartInteropAsync(() => ChartJsInterop.AddData(ChartJsConfig.ChartJsConfigGuid, e.Label, e.AtPosition, e.Datas))
             .ConfigureAwait(false);
     }
 
     private async void ChartJsConfig_LabelsSet(object? sender, LabelsSetEventArgs e)
     {
-        await ChartJsInterop.SetLabels(ChartJsConfig.ChartJsConfigGuid, e.Labels).ConfigureAwait(false);
+        await InvokeChartInteropAsync(() => ChartJsInterop.SetLabels(ChartJsConfig.ChartJsConfigGuid, e.Labels))
+            .ConfigureAwait(false);
     }
 
     private async void ChartJsConfig_DataSet(object? sender, DataSetEventArgs e)
     {
-        await ChartJsInterop.SetData(ChartJsConfig.ChartJsConfigGuid, e.Labels, e.Datas).ConfigureAwait(false);
+        await InvokeChartInteropAsync(() => ChartJsInterop.SetData(ChartJsConfig.ChartJsConfigGuid, e.Labels, e.Datas))
+            .ConfigureAwait(false);
     }
 
     private async void ChartJsConfig_DataRemove(object? sender, DataRemoveEventArgs e)
     {
-        await ChartJsInterop.RemoveData(ChartJsConfig.ChartJsConfigGuid).ConfigureAwait(false);
+        await InvokeChartInteropAsync(() => ChartJsInterop.RemoveData(ChartJsConfig.ChartJsConfigGuid))
+            .ConfigureAwait(false);
     }
 
     private async void ChartJsConfig_DataAdd(object? sender, DataAddEventArgs e)
     {
-        await ChartJsInterop.AddDataToDataset(
+        await InvokeChartInteropAsync(() => ChartJsInterop.AddDataToDataset(
             ChartJsConfig.ChartJsConfigGuid,
             e.Label,
             e.Data,
             e.BackgroundColors,
             e.BorderColors,
-            e.AtPostion).ConfigureAwait(false);
+            e.AtPostion)).ConfigureAwait(false);
     }
 
     private async void ChartJsConfig_DatasetsRemove(object? sender, DatasetsRemoveEventArgs e)
     {
-        await ChartJsInterop.RemoveDatasets(ChartJsConfig.ChartJsConfigGuid, e.DatasetIds).ConfigureAwait(false);
+        await InvokeChartInteropAsync(() => ChartJsInterop.RemoveDatasets(ChartJsConfig.ChartJsConfigGuid, e.DatasetIds))
+            .ConfigureAwait(false);
     }
 
     private async void ChartJsConfig_DatasetsAdd(object? sender, DatasetsAddEventArgs e)
     {
-        await ChartJsInterop.AddDatasets(ChartJsConfig.ChartJsConfigGuid, e.Datasets).ConfigureAwait(false);
+        await InvokeChartInteropAsync(() => ChartJsInterop.AddDatasets(ChartJsConfig.ChartJsConfigGuid, e.Datasets))
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -395,7 +404,6 @@ public partial class ChartComponent : ComponentBase, IAsyncDisposable
 
         if (disposing)
         {
-            await ChartJsInterop.DisposeChart(ChartJsConfig.ChartJsConfigGuid).ConfigureAwait(false);
             ChartJsConfig.DatasetsAdd -= ChartJsConfig_DatasetsAdd;
             ChartJsConfig.DatasetsRemove -= ChartJsConfig_DatasetsRemove;
             ChartJsConfig.DatasetsUpdate -= ChartJsConfig_DatasetsUpdate;
@@ -407,8 +415,26 @@ public partial class ChartComponent : ComponentBase, IAsyncDisposable
             ChartJsConfig.AddDataEvent -= ChartJsConfig_AddDataEvent;
             ChartJsConfig.ChartOptionsUpdate -= ChartJsConfig_ChartOptionsUpdate;
             ChartJsConfig.ChartRedraw -= ChartJsConfig_ChartRedraw;
+            isDisposed = true;
+
+            await ChartJsInterop.DisposeChart(ChartJsConfig.ChartJsConfigGuid).ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask InvokeChartInteropAsync(Func<ValueTask> action)
+    {
+        if (isDisposed)
+        {
+            return;
         }
 
-        isDisposed = true;
+        try
+        {
+            await action().ConfigureAwait(false);
+        }
+        catch (ObjectDisposedException) { }
+        catch (OperationCanceledException) { }
+        catch (JSDisconnectedException) { }
+        catch (JSException) when (isDisposed) { }
     }
 }

--- a/src/pax.BlazorChartJs/ChartComponent.razor.cs
+++ b/src/pax.BlazorChartJs/ChartComponent.razor.cs
@@ -70,7 +70,7 @@ public partial class ChartComponent : ComponentBase, IAsyncDisposable
             }
 
             var initResult = await ChartJsInterop.InitChart(ChartJsConfig, dotNetHelper).ConfigureAwait(false);
-            if (initResult.Success == true)
+            if (initResult.Success)
             {
                 await InvokeAsync(() =>
                     OnEventTriggered.InvokeAsync(new ChartJsInitEvent()
@@ -167,11 +167,11 @@ public partial class ChartComponent : ComponentBase, IAsyncDisposable
             try
             {
                 var initResult = await ChartJsInterop.InitChart(ChartJsConfig, dotNetHelper).ConfigureAwait(false);
-                if (initResult.Success == true)
+                if (initResult.Success)
                 {
                     await InvokeAsync(() => OnEventTriggered
-                        .InvokeAsync(new ChartJsInitEvent() 
-                        { 
+                        .InvokeAsync(new ChartJsInitEvent()
+                        {
                             ChartJsConfigGuid = ChartJsConfig.ChartJsConfigGuid,
                             Height = initResult.Height,
                             Width = initResult.Width,
@@ -197,7 +197,7 @@ public partial class ChartComponent : ComponentBase, IAsyncDisposable
         if (dotNetHelper != null)
         {
             var initResult = await ChartJsInterop.InitChart(ChartJsConfig, dotNetHelper).ConfigureAwait(false);
-            if (initResult.Success == true)
+            if (initResult.Success)
             {
                 await InvokeAsync(() =>
                     OnEventTriggered.InvokeAsync(new ChartJsInitEvent()
@@ -250,7 +250,7 @@ public partial class ChartComponent : ComponentBase, IAsyncDisposable
             if (chartJsEvent != null)
             {
                 chartJsEvent.ChartJsConfigGuid = ChartJsConfig.ChartJsConfigGuid;
-                OnEventTriggered.InvokeAsync(chartJsEvent);
+                _ = OnEventTriggered.InvokeAsync(chartJsEvent);
             }
         }
     }

--- a/src/pax.BlazorChartJs/ChartJsConfig/ChartJsConfig.AddData.cs
+++ b/src/pax.BlazorChartJs/ChartJsConfig/ChartJsConfig.AddData.cs
@@ -28,7 +28,7 @@ public partial class ChartJsConfig
 
         AddLabel(label, atPosition);
 
-        Dictionary<string, AddDataObject> jsData = new();
+        Dictionary<string, AddDataObject> jsData = [];
         foreach (var data in datas)
         {
             AddDatasetData(data.Key, data.Value.Data, data.Value.AtPosition);

--- a/src/pax.BlazorChartJs/ChartJsConfig/ChartJsConfig.Datasets.cs
+++ b/src/pax.BlazorChartJs/ChartJsConfig/ChartJsConfig.Datasets.cs
@@ -10,7 +10,7 @@ public partial class ChartJsConfig
     {
         ArgumentNullException.ThrowIfNull(dataset);
 
-        AddDatasets(new List<ChartJsDataset> { dataset });
+        AddDatasets([dataset]);
     }
 
     /// <summary>
@@ -39,7 +39,7 @@ public partial class ChartJsConfig
     public void RemoveDataset(ChartJsDataset dataset)
     {
         ArgumentNullException.ThrowIfNull(dataset);
-        RemoveDatasets(new List<ChartJsDataset>() { dataset });
+        RemoveDatasets([dataset]);
     }
 
     /// <summary>
@@ -49,7 +49,7 @@ public partial class ChartJsConfig
     {
         ArgumentNullException.ThrowIfNull(datasets);
 
-        List<string> removeDatasetIds = new();
+        List<string> removeDatasetIds = [];
 
         foreach (var dataset in datasets.ToArray())
         {
@@ -70,7 +70,7 @@ public partial class ChartJsConfig
     public void UpdateDataset(ChartJsDataset dataset)
     {
         ArgumentNullException.ThrowIfNull(dataset);
-        UpdateDatasets(new List<ChartJsDataset>() { dataset });
+        UpdateDatasets([dataset]);
     }
 
     /// <summary>

--- a/src/pax.BlazorChartJs/ChartJsConfig/ChartJsConfig.SetData.cs
+++ b/src/pax.BlazorChartJs/ChartJsConfig/ChartJsConfig.SetData.cs
@@ -16,7 +16,7 @@ public partial class ChartJsConfig
             Data.Labels = labels;
         }
 
-        Dictionary<string, SetDataObject> jsData = new();
+        Dictionary<string, SetDataObject> jsData = [];
         foreach (var data in datas)
         {
             data.Key.Data = data.Value.Data;

--- a/src/pax.BlazorChartJs/ChartJsConfig/ChartJsConfigEventArgs.cs
+++ b/src/pax.BlazorChartJs/ChartJsConfig/ChartJsConfigEventArgs.cs
@@ -1,66 +1,37 @@
 ﻿namespace pax.BlazorChartJs;
 
-public class DatasetsAddEventArgs : EventArgs
+public class DatasetsAddEventArgs(IList<ChartJsDataset> datasets) : EventArgs
 {
-    public DatasetsAddEventArgs(IList<ChartJsDataset> datasets)
-    {
-        Datasets = datasets;
-    }
-
-    public IList<ChartJsDataset> Datasets { get; init; }
+    public IList<ChartJsDataset> Datasets { get; init; } = datasets;
 }
 
-public class DatasetsRemoveEventArgs : EventArgs
+public class DatasetsRemoveEventArgs(IList<string> datasetIds) : EventArgs
 {
-    public DatasetsRemoveEventArgs(IList<string> datasetIds)
-    {
-        DatasetIds = datasetIds;
-    }
-
-    public IList<string> DatasetIds { get; init; }
+    public IList<string> DatasetIds { get; init; } = datasetIds;
 }
 
-public class DatasetsUpdateEventArgs : EventArgs
+public class DatasetsUpdateEventArgs(IList<ChartJsDataset> datasets, bool smooth = false) : EventArgs
 {
-    public DatasetsUpdateEventArgs(IList<ChartJsDataset> datasets, bool smooth = false)
-    {
-        Datasets = datasets;
-        Smooth = smooth;
-    }
-
-    public IList<ChartJsDataset> Datasets { get; init; }
-    public bool Smooth { get; init; }
+    public IList<ChartJsDataset> Datasets { get; init; } = datasets;
+    public bool Smooth { get; init; } = smooth;
 }
 
-public class DatasetsSetEventArgs : EventArgs
+public class DatasetsSetEventArgs(IList<ChartJsDataset> datasets) : EventArgs
 {
-    public DatasetsSetEventArgs(IList<ChartJsDataset> datasets)
-    {
-        Datasets = datasets;
-    }
-    public IList<ChartJsDataset> Datasets { get; init; }
+    public IList<ChartJsDataset> Datasets { get; init; } = datasets;
 }
 
-public class DataAddEventArgs : EventArgs
+public class DataAddEventArgs(string? label,
+                        IList<object> data,
+                        IList<string>? backgroundColors,
+                        IList<string>? borderColors,
+                        int? atPosition) : EventArgs
 {
-    public DataAddEventArgs(string? label,
-                            IList<object> data,
-                            IList<string>? backgroundColors,
-                            IList<string>? borderColors,
-                            int? atPosition)
-    {
-        Label = label;
-        Data = data;
-        BackgroundColors = backgroundColors;
-        BorderColors = borderColors;
-        AtPostion = atPosition;
-    }
-
-    public string? Label { get; init; }
-    public IList<object> Data { get; init; }
-    public IList<string>? BackgroundColors { get; init; }
-    public IList<string>? BorderColors { get; init; }
-    public int? AtPostion { get; init; }
+    public string? Label { get; init; } = label;
+    public IList<object> Data { get; init; } = data;
+    public IList<string>? BackgroundColors { get; init; } = backgroundColors;
+    public IList<string>? BorderColors { get; init; } = borderColors;
+    public int? AtPostion { get; init; } = atPosition;
 }
 
 public class DataRemoveEventArgs : EventArgs
@@ -70,38 +41,22 @@ public class DataRemoveEventArgs : EventArgs
     }
 }
 
-public class DataSetEventArgs : EventArgs
+public class DataSetEventArgs(Dictionary<string, SetDataObject> datas, IList<string>? labels = null) : EventArgs
 {
-    public DataSetEventArgs(Dictionary<string, SetDataObject> datas, IList<string>? labels = null)
-    {
-        Labels = labels;
-        Datas = datas;
-    }
-    public IList<string>? Labels { get; init; }
-    public Dictionary<string, SetDataObject> Datas { get; init; }
+    public IList<string>? Labels { get; init; } = labels;
+    public Dictionary<string, SetDataObject> Datas { get; init; } = datas;
 }
 
-public class LabelsSetEventArgs : EventArgs
+public class LabelsSetEventArgs(IList<string> labels) : EventArgs
 {
-    public LabelsSetEventArgs(IList<string> labels)
-    {
-        Labels = labels;
-    }
-
-    public IList<string> Labels { get; init; }
+    public IList<string> Labels { get; init; } = labels;
 }
 
-public class AddDataEventArgs : EventArgs
+public class AddDataEventArgs(string? label, int? atPosition, Dictionary<string, AddDataObject> datas) : EventArgs
 {
-    public AddDataEventArgs(string? label, int? atPosition, Dictionary<string, AddDataObject> datas)
-    {
-        Label = label;
-        Datas = datas;
-        AtPosition = atPosition;
-    }
-    public string? Label { get; init; }
-    public int? AtPosition { get; init; }
-    public Dictionary<string, AddDataObject> Datas { get; init; }
+    public string? Label { get; init; } = label;
+    public int? AtPosition { get; init; } = atPosition;
+    public Dictionary<string, AddDataObject> Datas { get; init; } = datas;
 }
 
 public record AddDataObject

--- a/src/pax.BlazorChartJs/ChartJsConfig/ChartJsData.cs
+++ b/src/pax.BlazorChartJs/ChartJsConfig/ChartJsData.cs
@@ -4,8 +4,8 @@ public record ChartJsData
 {
     public ChartJsData()
     {
-        Labels = new List<string>();
-        Datasets = new List<ChartJsDataset>();
+        Labels = [];
+        Datasets = [];
 
     }
 

--- a/src/pax.BlazorChartJs/ChartJsConfig/ChartJsDataset.cs
+++ b/src/pax.BlazorChartJs/ChartJsConfig/ChartJsDataset.cs
@@ -14,7 +14,7 @@ public record ChartJsDataset
     /// <summary>
     /// can be object|object[]| number[]|string[]
     /// </summary>    
-    public IList<object> Data { get; set; } = new List<object>();
+    public IList<object> Data { get; set; } = [];
     public ChartType? Type { get; set; }
     /// <summary>
     /// If you have a lot of data points, it can be more performant to enable spanGaps. 

--- a/src/pax.BlazorChartJs/ChartJsInterop.cs
+++ b/src/pax.BlazorChartJs/ChartJsInterop.cs
@@ -11,26 +11,17 @@ namespace pax.BlazorChartJs;
 /// <summary>
 /// ChartJsInterop
 /// </summary>
-public class ChartJsInterop : IAsyncDisposable
+/// <remarks>
+/// ChartJsInterop
+/// </remarks>
+public class ChartJsInterop(IJSRuntime jsRuntime,
+                      // ILogger<ChartJsInterop> logger,
+                      IOptions<ChartJsSetupOptions>? options) : IAsyncDisposable
 {
     private const string ChartJsInteropVersion = "0.8.8";
-    /// <summary>
-    /// ChartJsInterop
-    /// </summary>
-    public ChartJsInterop(IJSRuntime jsRuntime,
-                          // ILogger<ChartJsInterop> logger,
-                          IOptions<ChartJsSetupOptions>? options)
-    {
-        moduleTask = new(() => jsRuntime.InvokeAsync<IJSObjectReference>(
+    private readonly ChartJsSetupOptions? setupOptions = options?.Value;
+    private readonly Lazy<Task<IJSObjectReference>> moduleTask = new(() => jsRuntime.InvokeAsync<IJSObjectReference>(
             "import", $"./_content/pax.BlazorChartJs/chartJsInterop.js?v={ChartJsInteropVersion}").AsTask());
-
-        setupOptions = options?.Value;
-        JsRuntime = jsRuntime;
-
-        // this.logger = logger;
-    }
-    private readonly ChartJsSetupOptions? setupOptions;
-    private readonly Lazy<Task<IJSObjectReference>> moduleTask;
     // private readonly ILogger<ChartJsInterop> logger;
     private readonly JsonSerializerOptions jsonOptions = new()
     {
@@ -50,7 +41,7 @@ public class ChartJsInterop : IAsyncDisposable
             }
     };
 
-    public IJSRuntime JsRuntime { get; }
+    public IJSRuntime JsRuntime { get; } = jsRuntime;
 
 
 
@@ -101,7 +92,7 @@ public class ChartJsInterop : IAsyncDisposable
 
         var module = await moduleTask.Value.ConfigureAwait(false);
 
-        List<object> jsData = new();
+        List<object> jsData = [];
         foreach (var ent in data)
         {
             jsData.Add(new
@@ -404,13 +395,7 @@ public class ChartJsInterop : IAsyncDisposable
 
     private JsonObject? SerializeConfig(ChartJsConfig config)
     {
-        var json = JsonSerializer.Serialize<object>(config, jsonOptions);
-
-        if (json == null)
-        {
-            throw new ArgumentNullException(nameof(config));
-        }
-
+        var json = JsonSerializer.Serialize<object>(config, jsonOptions) ?? throw new ArgumentNullException(nameof(config));
         return JsonSerializer.Deserialize<JsonObject>(json);
     }
 
@@ -424,13 +409,7 @@ public class ChartJsInterop : IAsyncDisposable
             return null;
         }
 
-        var json = JsonSerializer.Serialize<object>(options, jsonOptions);
-
-        if (json == null)
-        {
-            throw new ArgumentNullException(nameof(config));
-        }
-
+        var json = JsonSerializer.Serialize<object>(options, jsonOptions) ?? throw new ArgumentNullException(nameof(config));
         return JsonSerializer.Deserialize<JsonObject>(json);
     }
 

--- a/src/pax.BlazorChartJs/ChartJsInterop.cs
+++ b/src/pax.BlazorChartJs/ChartJsInterop.cs
@@ -13,7 +13,7 @@ namespace pax.BlazorChartJs;
 /// </summary>
 public class ChartJsInterop : IAsyncDisposable
 {
-    private const string ChartJsInteropVersion = "0.8.7";
+    private const string ChartJsInteropVersion = "0.8.8";
     /// <summary>
     /// ChartJsInterop
     /// </summary>

--- a/src/pax.BlazorChartJs/ChartUtils.cs
+++ b/src/pax.BlazorChartJs/ChartUtils.cs
@@ -1,10 +1,10 @@
 ﻿namespace pax.BlazorChartJs;
+
 #pragma warning disable CA5394
 public static class ChartUtils
 {
-    private static Random random = new Random();
-    private static readonly List<string> Labels = new()
-    {
+    private static readonly List<string> Labels =
+    [
         "January",
         "February",
         "March",
@@ -17,9 +17,9 @@ public static class ChartUtils
         "October",
         "November",
         "December",
-    };
-    private static readonly List<string> Colors = new()
-    {
+    ];
+    private static readonly List<string> Colors =
+    [
         "#000000",
         "#FFFFFF",
         "#FF0000",
@@ -36,18 +36,18 @@ public static class ChartUtils
         "#800080",
         "#008080",
         "#000080",
-    };
+    ];
 
     public static string GetRandomColor()
     {
-        return Colors[random.Next(Colors.Count)];
+        return Colors[Random.Shared.Next(Colors.Count)];
     }
 
     public static ICollection<List<object>> GetRandomData(int length, int count, int min = -100, int max = 100)
     {
         ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(min, max);
 
-        List<List<object>> data = new List<List<object>>();
+        List<List<object>> data = [];
 
         for (int i = 0; i < length; i++)
         {
@@ -64,7 +64,7 @@ public static class ChartUtils
         {
             ChartType.bar => GetRandomBarDataset(id, count, min, max),
             ChartType.line => GetRandomLineDataset(id, count, min, max),
-            ChartType.pie => GetRandomPieDataset(id, count, min, max),
+            ChartType.pie => GetRandomPieDataset(count, min, max),
             ChartType.radar => GetRandomRadarDataset(id, count, min, max),
             ChartType.scatter => GetRandomScatterDataset(id, count, min, max),
             ChartType.bubble => GetRandomBubbleDataset(id, count, min, max),
@@ -77,9 +77,9 @@ public static class ChartUtils
         return new BarDataset()
         {
             Label = $"Dataset {id}",
-            BackgroundColor = new IndexableOption<string>(GetRandomColors(count)),
-            BorderColor = new IndexableOption<string>(GetRandomColors(count)),
-            BorderWidth = new IndexableOption<double>(1),
+            BackgroundColor = GetRandomColors(count),
+            BorderColor = GetRandomColors(count),
+            BorderWidth = 1,
             Data = GetRandomNumbers(count, min, max)
         };
     }
@@ -94,13 +94,14 @@ public static class ChartUtils
             Data = GetRandomNumbers(count, min, max)
         };
     }
-    private static PieDataset GetRandomPieDataset(int id, int count, int min, int max)
+
+    private static PieDataset GetRandomPieDataset(int count, int min, int max)
     {
         return new PieDataset()
         {
-            BackgroundColor = new IndexableOption<string>(GetRandomColors(count)),
-            BorderColor = new IndexableOption<string>(GetRandomColors(count)),
-            BorderWidth = new IndexableOption<double>(1),
+            BackgroundColor = GetRandomColors(count),
+            BorderColor = GetRandomColors(count),
+            BorderWidth = 1,
             Data = GetRandomNumbers(count, min, max)
         };
     }
@@ -128,8 +129,8 @@ public static class ChartUtils
         {
             data.Add(new DataPoint()
             {
-                X = random.Next(min, max),
-                Y = random.Next(min, max)
+                X = Random.Shared.Next(min, max),
+                Y = Random.Shared.Next(min, max)
             });
         }
 
@@ -145,21 +146,21 @@ public static class ChartUtils
     {
         var backgroundColor = GetRandomColors(1).First();
 
-        List<object> data = new();
+        List<object> data = [];
         for (int i = 0; i < count; i++)
         {
             data.Add(new BubbleDataPoint()
             {
-                X = random.Next(min, max),
-                Y = random.Next(min, max),
-                R = random.Next(1, 15)
+                X = Random.Shared.Next(min, max),
+                Y = Random.Shared.Next(min, max),
+                R = Random.Shared.Next(1, 15)
             });
         }
 
         return new BubbleDataset()
         {
             Label = $"Dataset {id}",
-            BackgroundColor = new IndexableOption<string>(backgroundColor),
+            BackgroundColor = backgroundColor,
             Data = data
         };
     }
@@ -168,16 +169,16 @@ public static class ChartUtils
     {
         ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(min, max);
 
-        var label = Labels[random.Next(Labels.Count)];
-        List<object> data = new();
-        List<string> backgroundColors = new();
-        List<string> borderColors = new();
+        var label = Labels[Random.Shared.Next(Labels.Count)];
+        List<object> data = [];
+        List<string> backgroundColors = [];
+        List<string> borderColors = [];
 
         for (int i = 0; i < count; i++)
         {
-            data.Add(random.Next(min, max));
-            backgroundColors.Add(Colors[random.Next(Colors.Count)]);
-            borderColors.Add(Colors[random.Next(Colors.Count)]);
+            data.Add(Random.Shared.Next(min, max));
+            backgroundColors.Add(Colors[Random.Shared.Next(Colors.Count)]);
+            borderColors.Add(Colors[Random.Shared.Next(Colors.Count)]);
         }
 
         return new DataAddEventArgs(label, data, backgroundColors, borderColors, null);
@@ -188,7 +189,7 @@ public static class ChartUtils
         var colors = new List<string>();
         for (int i = 0; i < count; i++)
         {
-            colors.Add(Colors[random.Next(Colors.Count)]);
+            colors.Add(Colors[Random.Shared.Next(Colors.Count)]);
         }
         return colors;
     }
@@ -198,7 +199,7 @@ public static class ChartUtils
         var numbers = new List<object>();
         for (int i = 0; i < count; i++)
         {
-            numbers.Add(random.Next(min, max));
+            numbers.Add(Random.Shared.Next(min, max));
         }
         return numbers;
     }

--- a/src/pax.BlazorChartJs/IndexableOption.cs
+++ b/src/pax.BlazorChartJs/IndexableOption.cs
@@ -10,31 +10,17 @@ namespace pax.BlazorChartJs;
 [CollectionBuilder(typeof(IndexableOptionBuilder), "Create")]
 public class IndexableOption<T> : IEnumerable<T>
 {
-    private List<T>? _indexedValues;
+    private readonly List<T>? _indexedValues;
 
     /// <summary>
     /// The indexed values represented by this instance.
     /// </summary>
-    public IList<T>? IndexedValues
-    {
-        get
-        {
-            return _indexedValues;
-        }
-    }
-
-    private T? _singleValue;
+    public IList<T>? IndexedValues => _indexedValues;
 
     /// <summary>
     /// The single value represented by this instance.
     /// </summary>
-    public T? SingleValue
-    {
-        get
-        {
-            return _singleValue;
-        }
-    }
+    public T? SingleValue { get; }
 
     /// <summary>
     /// Gets the value indicating whether the option wrapped in this <see cref="IndexableOption{T}"/> is indexed.
@@ -48,7 +34,7 @@ public class IndexableOption<T> : IEnumerable<T>
     /// <param name="singleValue">The single value this <see cref="IndexableOption{T}"/> should represent.</param>
     public IndexableOption(T singleValue)
     {
-        _singleValue = singleValue;
+        SingleValue = singleValue;
         IsIndexed = false;
     }
 
@@ -58,13 +44,13 @@ public class IndexableOption<T> : IEnumerable<T>
     /// <param name="indexedValues">The IList of values this <see cref="IndexableOption{T}"/> should represent.</param>
     public IndexableOption(IList<T> indexedValues)
     {
-        _indexedValues = new List<T>(indexedValues);
+        _indexedValues = [.. indexedValues];
         IsIndexed = true;
     }
 
     public IndexableOption(ICollection<T> values)
     {
-        _indexedValues = new List<T>(values);
+        _indexedValues = [.. values];
         IsIndexed = true;
     }
 
@@ -93,28 +79,40 @@ public class IndexableOption<T> : IEnumerable<T>
 
     public void Remove(T item)
     {
-        _indexedValues?.Remove(item);
+        _ = _indexedValues?.Remove(item);
     }
 
     public IndexableOption<T> FromT(T value)
-        => new(value);
+    {
+        return new(value);
+    }
 
     public static implicit operator IndexableOption<T>(T value)
-        => new(value);
+    {
+        return new(value);
+    }
 
 #pragma warning disable CA1002 // Do not expose generic lists
     public IndexableOption<T> FromList(List<T> value)
-        => new(value);
+    {
+        return [.. value];
+    }
 
     public static implicit operator IndexableOption<T>(List<T> value)
-        => new(value);
+    {
+        return [.. value];
+    }
 #pragma warning restore CA1002 // Do not expose generic lists
 
     public IndexableOption<T> FromCollection(Collection<T> value)
-    => new(value);
+    {
+        return [.. value];
+    }
 
     public static implicit operator IndexableOption<T>(Collection<T> value)
-        => new(value);
+    {
+        return [.. value];
+    }
 
     internal object GetJsonObject()
     {
@@ -125,18 +123,11 @@ public class IndexableOption<T> : IEnumerable<T>
 
     public IEnumerator<T> GetEnumerator()
     {
-        if (_indexedValues is not null)
-        {
-            return _indexedValues.GetEnumerator();
-        }
-        else if (_singleValue is not null)
-        {
-            return new List<T>() { _singleValue }.GetEnumerator();
-        }
-        else
-        {
-            throw new ArgumentNullException(nameof(IndexedValues));
-        }
+        return _indexedValues is not null
+            ? _indexedValues.GetEnumerator()
+            : SingleValue is not null
+                ? (IEnumerator<T>)new List<T>() { SingleValue }.GetEnumerator()
+                : throw new ArgumentNullException(nameof(IndexedValues));
     }
 
     IEnumerator IEnumerable.GetEnumerator()
@@ -148,6 +139,9 @@ public class IndexableOption<T> : IEnumerable<T>
 
 public static class IndexableOptionBuilder
 {
-    public static IndexableOption<T> Create<T>(ReadOnlySpan<T> values) => new IndexableOption<T>(values);
+    public static IndexableOption<T> Create<T>(ReadOnlySpan<T> values)
+    {
+        return new IndexableOption<T>(values);
+    }
 }
 

--- a/src/pax.BlazorChartJs/JsonConverters.cs
+++ b/src/pax.BlazorChartJs/JsonConverters.cs
@@ -7,7 +7,9 @@ namespace pax.BlazorChartJs;
 internal sealed class IndexableOptionStringConverter : JsonConverter<IndexableOption<string>?>
 {
     public override IndexableOption<string>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-     => throw new NotImplementedException();
+    {
+        throw new NotImplementedException();
+    }
 
     public override void Write(Utf8JsonWriter writer, IndexableOption<string>? value, JsonSerializerOptions options)
     {
@@ -22,7 +24,9 @@ internal sealed class IndexableOptionStringConverter : JsonConverter<IndexableOp
 internal sealed class IndexableOptionDoubleConverter : JsonConverter<IndexableOption<double>?>
 {
     public override IndexableOption<double>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-     => throw new NotImplementedException();
+    {
+        throw new NotImplementedException();
+    }
 
     public override void Write(Utf8JsonWriter writer, IndexableOption<double>? value, JsonSerializerOptions options)
     {
@@ -37,7 +41,9 @@ internal sealed class IndexableOptionDoubleConverter : JsonConverter<IndexableOp
 internal sealed class IndexableOptionIntConverter : JsonConverter<IndexableOption<int>?>
 {
     public override IndexableOption<int>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-     => throw new NotImplementedException();
+    {
+        throw new NotImplementedException();
+    }
 
     public override void Write(Utf8JsonWriter writer, IndexableOption<int>? value, JsonSerializerOptions options)
     {
@@ -52,7 +58,9 @@ internal sealed class IndexableOptionIntConverter : JsonConverter<IndexableOptio
 internal sealed class IndexableOptionBoolConverter : JsonConverter<IndexableOption<bool>?>
 {
     public override IndexableOption<bool>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-     => throw new NotImplementedException();
+    {
+        throw new NotImplementedException();
+    }
 
     public override void Write(Utf8JsonWriter writer, IndexableOption<bool>? value, JsonSerializerOptions options)
     {
@@ -67,7 +75,9 @@ internal sealed class IndexableOptionBoolConverter : JsonConverter<IndexableOpti
 internal sealed class StringOrDoubleValueConverter : JsonConverter<StringOrDoubleValue>
 {
     public override StringOrDoubleValue? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-     => throw new NotImplementedException();
+    {
+        throw new NotImplementedException();
+    }
 
     public override void Write(Utf8JsonWriter writer, StringOrDoubleValue? value, JsonSerializerOptions options)
     {
@@ -83,7 +93,9 @@ internal sealed class StringOrDoubleValueConverter : JsonConverter<StringOrDoubl
 internal sealed class IndexableOptionObjectConverter : JsonConverter<IndexableOption<object>?>
 {
     public override IndexableOption<object>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-     => throw new NotImplementedException();
+    {
+        throw new NotImplementedException();
+    }
 
     public override void Write(Utf8JsonWriter writer, IndexableOption<object>? value, JsonSerializerOptions options)
     {
@@ -117,7 +129,9 @@ internal sealed class ChartJsDatasetJsonConverter : JsonConverter<ChartJsDataset
     };
 
     public override ChartJsDataset? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-     => throw new NotImplementedException();
+    {
+        throw new NotImplementedException();
+    }
 
     public override void Write(Utf8JsonWriter writer, ChartJsDataset? value, JsonSerializerOptions options)
     {
@@ -125,7 +139,7 @@ internal sealed class ChartJsDatasetJsonConverter : JsonConverter<ChartJsDataset
         {
             return;
         }
-        writer.WriteRawValue(JsonSerializer.Serialize<object>((object)value, writeOptions), true);
+        writer.WriteRawValue(JsonSerializer.Serialize<object>(value, writeOptions), true);
     }
 }
 
@@ -151,7 +165,9 @@ internal sealed class ChartJsAxisJsonConverter : JsonConverter<ChartJsAxis?>
     };
 
     public override ChartJsAxis? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-     => throw new NotImplementedException();
+    {
+        throw new NotImplementedException();
+    }
 
     public override void Write(Utf8JsonWriter writer, ChartJsAxis? value, JsonSerializerOptions options)
     {
@@ -159,7 +175,7 @@ internal sealed class ChartJsAxisJsonConverter : JsonConverter<ChartJsAxis?>
         {
             return;
         }
-        writer.WriteRawValue(JsonSerializer.Serialize<object>((object)value, writeOptoins), true);
+        writer.WriteRawValue(JsonSerializer.Serialize<object>(value, writeOptoins), true);
     }
 }
 
@@ -182,7 +198,9 @@ internal sealed class ChartJsAxisTickJsonConverter : JsonConverter<ChartJsAxisTi
     };
 
     public override ChartJsAxisTick? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-     => throw new NotImplementedException();
+    {
+        throw new NotImplementedException();
+    }
 
     public override void Write(Utf8JsonWriter writer, ChartJsAxisTick? value, JsonSerializerOptions options)
     {
@@ -190,6 +208,6 @@ internal sealed class ChartJsAxisTickJsonConverter : JsonConverter<ChartJsAxisTi
         {
             return;
         }
-        writer.WriteRawValue(JsonSerializer.Serialize<object>((object)value, writeOptions), true);
+        writer.WriteRawValue(JsonSerializer.Serialize<object>(value, writeOptions), true);
     }
 }

--- a/src/pax.BlazorChartJs/ServiceCollectionExtensions.cs
+++ b/src/pax.BlazorChartJs/ServiceCollectionExtensions.cs
@@ -15,7 +15,7 @@ public static class ServiceCollectionExtensions
     {
         if (setupAction != null)
         {
-            services.Configure(setupAction);
+            _ = services.Configure(setupAction);
         }
 
         return services.AddScoped<ChartJsInterop, ChartJsInterop>();

--- a/src/pax.BlazorChartJs/StringOrDoubleValue.cs
+++ b/src/pax.BlazorChartJs/StringOrDoubleValue.cs
@@ -18,40 +18,47 @@ public record StringOrDoubleValue
         DoubleValue = doubleValue;
     }
 
-    public string? AsString() => StringValue;
-    public double? AsDouble() => DoubleValue;
+    public string? AsString()
+    {
+        return StringValue;
+    }
+
+    public double? AsDouble()
+    {
+        return DoubleValue;
+    }
 
     public bool IsString => StringValue != null;
     public bool IsDouble => DoubleValue != null;
 
     public static StringOrDoubleValue FromString(string stringValue)
-        => new(stringValue);
+    {
+        return new(stringValue);
+    }
 
     public static StringOrDoubleValue FromDouble(double doubleValue)
-        => new(doubleValue);
+    {
+        return new(doubleValue);
+    }
 
     public static implicit operator StringOrDoubleValue(string stringValue)
-        => new(stringValue);
+    {
+        return new(stringValue);
+    }
 
     public static implicit operator StringOrDoubleValue(double doubleValue)
-        => new(doubleValue);
+    {
+        return new(doubleValue);
+    }
 
     public override string ToString()
-        => IsString ? AsString()! : AsDouble()?.ToString(CultureInfo.InvariantCulture)! ?? "";
+    {
+        return IsString ? AsString()! : AsDouble()?.ToString(CultureInfo.InvariantCulture)! ?? "";
+    }
 
     internal object GetJsonObject()
     {
-        if (StringValue != null)
-        {
-            return StringValue;
-        }
-        else if (DoubleValue != null)
-        {
-            return DoubleValue.Value;
-        }
-        else
-        {
-            throw new ArgumentNullException("String and Double values are null");
-        }
+        return StringValue ?? (DoubleValue != null ? (object)DoubleValue.Value
+        : throw new ArgumentNullException("String and Double values are null"));
     }
 }

--- a/src/pax.BlazorChartJs/TypeScript/chartJsInterop.ts
+++ b/src/pax.BlazorChartJs/TypeScript/chartJsInterop.ts
@@ -367,21 +367,30 @@ async function initChartCore(setupOptions: any, chartId: string, dotnetConfig: a
 }
 
 function destroyExistingChart(chartId: string, element?: HTMLCanvasElement | null) {
-    const charts = [
-        ChartJsInteropModule.charts.get(chartId)
-    ];
-    if (typeof Chart !== "undefined") {
-        charts.push(
-            element ? Chart.getChart(element) : undefined,
-            Chart.getChart(chartId));
+    const mappedChart = ChartJsInteropModule.charts.get(chartId);
+    let destroyedChart: any | undefined;
+    let destroyedElementChart: any | undefined;
+
+    if (mappedChart != undefined) {
+        mappedChart.destroy();
+        destroyedChart = mappedChart;
     }
-    const destroyedCharts = new Set<any>();
-    for (const chart of charts) {
-        if (chart != undefined && !destroyedCharts.has(chart)) {
-            destroyedCharts.add(chart);
-            chart.destroy();
+
+    if (typeof Chart !== "undefined") {
+        const elementChart = element ? Chart.getChart(element) : undefined;
+        if (elementChart != undefined && elementChart !== destroyedChart) {
+            elementChart.destroy();
+            destroyedElementChart = elementChart;
+        }
+
+        const idChart = Chart.getChart(chartId);
+        if (idChart != undefined
+            && idChart !== destroyedChart
+            && idChart !== destroyedElementChart) {
+            idChart.destroy();
         }
     }
+
     ChartJsInteropModule.charts.delete(chartId);
     ChartJsInteropModule.dotnetRefs.delete(chartId);
 }
@@ -531,11 +540,16 @@ async function triggerEvent(chartId: string, event: string, source: string, data
 }
 
 function getLiveChart(chartId: string): any | undefined {
+    const mappedChart = ChartJsInteropModule.charts.get(chartId);
+    if (mappedChart && mappedChart.data) {
+        return mappedChart;
+    }
+
     if (typeof Chart === "undefined") {
         return undefined;
     }
 
-    const chart = Chart.getChart(chartId) ?? ChartJsInteropModule.charts.get(chartId);
+    const chart = Chart.getChart(chartId);
     return chart && chart.data ? chart : undefined;
 }
 

--- a/src/pax.BlazorChartJs/TypeScript/chartJsInterop.ts
+++ b/src/pax.BlazorChartJs/TypeScript/chartJsInterop.ts
@@ -1,5 +1,5 @@
-// v0.8.7
-export const chartJsInteropVersion = "0.8.7";
+// v0.8.8
+export const chartJsInteropVersion = "0.8.8";
 
 declare const Chart: any;
 declare const ChartDataLabels: any;
@@ -126,6 +126,9 @@ class ChartJsInterop {
     }
 
     public removeData(chart: any) {
+        if (!chart || !chart.data) {
+            return;
+        }
 
         if (!(chart.data.labels.length == 0)) {
             chart.data.labels.pop();
@@ -150,6 +153,10 @@ class ChartJsInterop {
     }
 
     public setData(chart: any, labels: string[], datas: any) {
+        if (!chart || !chart.data) {
+            return;
+        }
+
         if (labels != undefined) {
             chart.data.labels = labels;
         }
@@ -173,6 +180,10 @@ class ChartJsInterop {
     }
 
     public addDatasets(chart: any, datasets: any[]) {
+        if (!chart || !chart.data) {
+            return;
+        }
+
         for (let i = 0; i < datasets.length; i++) {
             chart.data.datasets.push(datasets[i]);
         }
@@ -180,6 +191,10 @@ class ChartJsInterop {
     }
 
     public removeDatasets(chart: any, datasetIds: string[]) {
+        if (!chart || !chart.data) {
+            return;
+        }
+
         for (const index of this.reverseKeys(chart.data.datasets)) {
             const dataset = chart.data.datasets[index];
             if (datasetIds.includes(dataset['id'])) {
@@ -190,6 +205,9 @@ class ChartJsInterop {
     }
 
     public updateDatasetsSmooth(chart: any, datasets: any[]) {
+        if (!chart || !chart.data) {
+            return;
+        }
 
         datasets.forEach((newDataset: any) => {
             const datasetIndex = chart.data.datasets.findIndex((dataset: any) => dataset['id'] === newDataset['id']);
@@ -209,6 +227,9 @@ class ChartJsInterop {
     }
 
     public updateDatasets(chart: any, datasets: any[]) {
+        if (!chart || !chart.data) {
+            return;
+        }
 
         datasets.forEach((dataset: any) => {
             const datasetIndex = chart.data.datasets.findIndex((existingDataset: any) => existingDataset['id'] === dataset['id']);
@@ -220,6 +241,10 @@ class ChartJsInterop {
     }
 
     public setDatasets(chart: any, datasets: any[]) {
+        if (!chart || !chart.data) {
+            return;
+        }
+
         chart.data.datasets = datasets;
         chart.update();
     }
@@ -505,8 +530,17 @@ async function triggerEvent(chartId: string, event: string, source: string, data
     await ChartJsInteropModule.triggerEvent(chartId, event, source, data);
 }
 
+function getLiveChart(chartId: string): any | undefined {
+    if (typeof Chart === "undefined") {
+        return undefined;
+    }
+
+    const chart = Chart.getChart(chartId) ?? ChartJsInteropModule.charts.get(chartId);
+    return chart && chart.data ? chart : undefined;
+}
+
 export function updateChartOptions(chartId: string, options: any) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
     if (chart != undefined) {
         chart.options = options;
         chart.update();
@@ -515,49 +549,70 @@ export function updateChartOptions(chartId: string, options: any) {
 }
 
 export function addData(chartId: string, label: string, pos: number, datas: any) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
     ChartJsInteropModule.addData(chart, label, pos, datas);
 }
 
 export function removeData(chartId: string) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     ChartJsInteropModule.removeData(chart);
 }
 
 export function setData(chartId: string, labels: string[], datas: any) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     ChartJsInteropModule.setData(chart, labels, datas);
 }
 
 export function addDatasets(chartId: string, datasets: any[]) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     ChartJsInteropModule.addDatasets(chart, datasets);
 }
 
 export function removeDatasets(chartId: string, datasets: string[]) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     ChartJsInteropModule.removeDatasets(chart, datasets);
 }
 
 export function updateDatasetsSmooth(chartId: string, datasets: any[]) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     ChartJsInteropModule.updateDatasetsSmooth(chart, datasets);
 }
 
 export function updateDatasets(chartId: string, datasets: any[]) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     ChartJsInteropModule.updateDatasets(chart, datasets);
 }
 
 export function setDatasets(chartId: string, datasets: any[]) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     ChartJsInteropModule.setDatasets(chart, datasets);
 }
 
 // - ts
 export function setLabels(chartId: string, labels: string[]) {
-    const chart = Chart.getChart(chartId);
-    if (!chart || !chart.data) {
+    const chart = getLiveChart(chartId);
+    if (!chart) {
         return;
     }
     chart.data.labels = labels;
@@ -565,7 +620,7 @@ export function setLabels(chartId: string, labels: string[]) {
 }
 
 export function resizeChart(chartId: string, width?: number, height?: number) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
     if (chart == undefined) {
         return;
     }
@@ -579,7 +634,10 @@ export function resizeChart(chartId: string, width?: number, height?: number) {
 
 export function getChartImage(chartId: string, type?: string, quality?: number, width?: number, height?: number) {
 
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return "";
+    }
     let currentWidth = 0;
     let currentHeight = 0;
     if (!(width == undefined || height == undefined)) {
@@ -618,39 +676,60 @@ export function getChartImage(chartId: string, type?: string, quality?: number, 
 }
 
 export function resetChart(chartId: string) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     chart.reset();
 }
 
 export function renderChart(chartId: string) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     chart.render();
 }
 
 export function stopChart(chartId: string) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     chart.stop();
 }
 
 export function setDatasetVisibility(chartId: string, datasetIndex: number, value: boolean) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     chart.setDatasetVisibility(datasetIndex, value);
     chart.update();
 }
 
 export function toggleDataVisibility(chartId: string, index: number) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     chart.toggleDataVisibility(index);
     chart.update();
 }
 
 export function getDataVisibility(chartId: string, index: number): boolean {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return false;
+    }
     return chart.getDataVisibility(index);
 }
 
 export function hideDataset(chartId: string, datasetId: string, dataIndex?: number) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     const datasetMetas = chart.getSortedVisibleDatasetMetas();
     const datasetIndex = datasetMetas.findIndex((obj: any) => obj._dataset.id === datasetId);
     if (dataIndex == undefined) {
@@ -661,7 +740,10 @@ export function hideDataset(chartId: string, datasetId: string, dataIndex?: numb
 }
 
 export function showDataset(chartId: string, datasetIndex: number, dataIndex?: number) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     if (dataIndex == undefined) {
         chart.show(datasetIndex);
     } else {
@@ -670,19 +752,28 @@ export function showDataset(chartId: string, datasetIndex: number, dataIndex?: n
 }
 
 export function getLabels(chartId: string) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return [];
+    }
     const items = chart.options.plugins.legend.labels.generateLabels(chart);
     return items;
 }
 
 export function isDatasetVisible(chartId: string, datasetIndex: number): boolean {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return false;
+    }
     const isVisible = chart.isDatasetVisible(datasetIndex);
     return isVisible;
 }
 
 export function setDatasetPointsActive(chartId: string, datasetIndex: number) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
 
     if (chart.getActiveElements().length > 0) {
         chart.setActiveElements([]);

--- a/src/pax.BlazorChartJs/pax.BlazorChartJs.csproj
+++ b/src/pax.BlazorChartJs/pax.BlazorChartJs.csproj
@@ -9,12 +9,12 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/ipax77/pax.BlazorChartJs</RepositoryUrl>
     <PackageTags>blazor;dotnet;wrapper;chartjs</PackageTags>
-    <AssemblyVersion>0.8.7.0</AssemblyVersion>
+    <AssemblyVersion>0.8.8.0</AssemblyVersion>
     <Owners>Philipp Hetzner</Owners>
     <Authors>Philipp Hetzner</Authors>
-    <Version>0.8.7</Version>
-	  <FileVersion>0.8.7.0</FileVersion>
-    <PackageVersion>0.8.7</PackageVersion>
+    <Version>0.8.8</Version>
+	  <FileVersion>0.8.8.0</FileVersion>
+    <PackageVersion>0.8.8</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>    
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/src/pax.BlazorChartJs/pax.BlazorChartJs.csproj
+++ b/src/pax.BlazorChartJs/pax.BlazorChartJs.csproj
@@ -30,7 +30,7 @@
     <LangVersion>latest</LangVersion>
     <WarningsNotAsErrors></WarningsNotAsErrors>
     <DisabledWarnings>1591</DisabledWarnings>
-    <NoWarn>1591</NoWarn>
+    <NoWarn>1591, IDE0160, IDE0130, IDE0008, IDE0072</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/pax.BlazorChartJs/wwwroot/chartJsInterop.js
+++ b/src/pax.BlazorChartJs/wwwroot/chartJsInterop.js
@@ -304,17 +304,24 @@ async function initChartCore(setupOptions, chartId, dotnetConfig, dotnetRef) {
     }
 }
 function destroyExistingChart(chartId, element) {
-    const charts = [
-        ChartJsInteropModule.charts.get(chartId)
-    ];
-    if (typeof Chart !== "undefined") {
-        charts.push(element ? Chart.getChart(element) : undefined, Chart.getChart(chartId));
+    const mappedChart = ChartJsInteropModule.charts.get(chartId);
+    let destroyedChart;
+    let destroyedElementChart;
+    if (mappedChart != undefined) {
+        mappedChart.destroy();
+        destroyedChart = mappedChart;
     }
-    const destroyedCharts = new Set();
-    for (const chart of charts) {
-        if (chart != undefined && !destroyedCharts.has(chart)) {
-            destroyedCharts.add(chart);
-            chart.destroy();
+    if (typeof Chart !== "undefined") {
+        const elementChart = element ? Chart.getChart(element) : undefined;
+        if (elementChart != undefined && elementChart !== destroyedChart) {
+            elementChart.destroy();
+            destroyedElementChart = elementChart;
+        }
+        const idChart = Chart.getChart(chartId);
+        if (idChart != undefined
+            && idChart !== destroyedChart
+            && idChart !== destroyedElementChart) {
+            idChart.destroy();
         }
     }
     ChartJsInteropModule.charts.delete(chartId);
@@ -434,10 +441,14 @@ async function triggerEvent(chartId, event, source, data) {
     await ChartJsInteropModule.triggerEvent(chartId, event, source, data);
 }
 function getLiveChart(chartId) {
+    const mappedChart = ChartJsInteropModule.charts.get(chartId);
+    if (mappedChart && mappedChart.data) {
+        return mappedChart;
+    }
     if (typeof Chart === "undefined") {
         return undefined;
     }
-    const chart = Chart.getChart(chartId) ?? ChartJsInteropModule.charts.get(chartId);
+    const chart = Chart.getChart(chartId);
     return chart && chart.data ? chart : undefined;
 }
 export function updateChartOptions(chartId, options) {

--- a/src/pax.BlazorChartJs/wwwroot/chartJsInterop.js
+++ b/src/pax.BlazorChartJs/wwwroot/chartJsInterop.js
@@ -1,4 +1,4 @@
-export const chartJsInteropVersion = "0.8.7";
+export const chartJsInteropVersion = "0.8.8";
 class LoadInfo {
     constructor() {
         this.chartJsLoaded = false;
@@ -108,6 +108,9 @@ class ChartJsInterop {
         }
     }
     removeData(chart) {
+        if (!chart || !chart.data) {
+            return;
+        }
         if (!(chart.data.labels.length == 0)) {
             chart.data.labels.pop();
         }
@@ -127,6 +130,9 @@ class ChartJsInterop {
         chart.update();
     }
     setData(chart, labels, datas) {
+        if (!chart || !chart.data) {
+            return;
+        }
         if (labels != undefined) {
             chart.data.labels = labels;
         }
@@ -145,12 +151,18 @@ class ChartJsInterop {
         chart.update();
     }
     addDatasets(chart, datasets) {
+        if (!chart || !chart.data) {
+            return;
+        }
         for (let i = 0; i < datasets.length; i++) {
             chart.data.datasets.push(datasets[i]);
         }
         chart.update();
     }
     removeDatasets(chart, datasetIds) {
+        if (!chart || !chart.data) {
+            return;
+        }
         for (const index of this.reverseKeys(chart.data.datasets)) {
             const dataset = chart.data.datasets[index];
             if (datasetIds.includes(dataset['id'])) {
@@ -160,6 +172,9 @@ class ChartJsInterop {
         chart.update();
     }
     updateDatasetsSmooth(chart, datasets) {
+        if (!chart || !chart.data) {
+            return;
+        }
         datasets.forEach((newDataset) => {
             const datasetIndex = chart.data.datasets.findIndex((dataset) => dataset['id'] === newDataset['id']);
             if (datasetIndex >= 0) {
@@ -175,6 +190,9 @@ class ChartJsInterop {
         chart.update();
     }
     updateDatasets(chart, datasets) {
+        if (!chart || !chart.data) {
+            return;
+        }
         datasets.forEach((dataset) => {
             const datasetIndex = chart.data.datasets.findIndex((existingDataset) => existingDataset['id'] === dataset['id']);
             if (datasetIndex >= 0) {
@@ -184,6 +202,9 @@ class ChartJsInterop {
         chart.update();
     }
     setDatasets(chart, datasets) {
+        if (!chart || !chart.data) {
+            return;
+        }
         chart.data.datasets = datasets;
         chart.update();
     }
@@ -412,8 +433,15 @@ function getChartPointEventArgs(e, chart) {
 async function triggerEvent(chartId, event, source, data) {
     await ChartJsInteropModule.triggerEvent(chartId, event, source, data);
 }
+function getLiveChart(chartId) {
+    if (typeof Chart === "undefined") {
+        return undefined;
+    }
+    const chart = Chart.getChart(chartId) ?? ChartJsInteropModule.charts.get(chartId);
+    return chart && chart.data ? chart : undefined;
+}
 export function updateChartOptions(chartId, options) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
     if (chart != undefined) {
         chart.options = options;
         chart.update();
@@ -421,47 +449,68 @@ export function updateChartOptions(chartId, options) {
     }
 }
 export function addData(chartId, label, pos, datas) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
     ChartJsInteropModule.addData(chart, label, pos, datas);
 }
 export function removeData(chartId) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     ChartJsInteropModule.removeData(chart);
 }
 export function setData(chartId, labels, datas) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     ChartJsInteropModule.setData(chart, labels, datas);
 }
 export function addDatasets(chartId, datasets) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     ChartJsInteropModule.addDatasets(chart, datasets);
 }
 export function removeDatasets(chartId, datasets) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     ChartJsInteropModule.removeDatasets(chart, datasets);
 }
 export function updateDatasetsSmooth(chartId, datasets) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     ChartJsInteropModule.updateDatasetsSmooth(chart, datasets);
 }
 export function updateDatasets(chartId, datasets) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     ChartJsInteropModule.updateDatasets(chart, datasets);
 }
 export function setDatasets(chartId, datasets) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     ChartJsInteropModule.setDatasets(chart, datasets);
 }
 export function setLabels(chartId, labels) {
-    const chart = Chart.getChart(chartId);
-    if (!chart || !chart.data) {
+    const chart = getLiveChart(chartId);
+    if (!chart) {
         return;
     }
     chart.data.labels = labels;
     chart.update();
 }
 export function resizeChart(chartId, width, height) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
     if (chart == undefined) {
         return;
     }
@@ -474,7 +523,10 @@ export function resizeChart(chartId, width, height) {
     chart.options.onResize?.(chart, { height: chart.height, width: chart.width });
 }
 export function getChartImage(chartId, type, quality, width, height) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return "";
+    }
     let currentWidth = 0;
     let currentHeight = 0;
     if (!(width == undefined || height == undefined)) {
@@ -502,33 +554,54 @@ export function getChartImage(chartId, type, quality, width, height) {
     return chartImg;
 }
 export function resetChart(chartId) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     chart.reset();
 }
 export function renderChart(chartId) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     chart.render();
 }
 export function stopChart(chartId) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     chart.stop();
 }
 export function setDatasetVisibility(chartId, datasetIndex, value) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     chart.setDatasetVisibility(datasetIndex, value);
     chart.update();
 }
 export function toggleDataVisibility(chartId, index) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     chart.toggleDataVisibility(index);
     chart.update();
 }
 export function getDataVisibility(chartId, index) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return false;
+    }
     return chart.getDataVisibility(index);
 }
 export function hideDataset(chartId, datasetId, dataIndex) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     const datasetMetas = chart.getSortedVisibleDatasetMetas();
     const datasetIndex = datasetMetas.findIndex((obj) => obj._dataset.id === datasetId);
     if (dataIndex == undefined) {
@@ -539,7 +612,10 @@ export function hideDataset(chartId, datasetId, dataIndex) {
     }
 }
 export function showDataset(chartId, datasetIndex, dataIndex) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     if (dataIndex == undefined) {
         chart.show(datasetIndex);
     }
@@ -548,17 +624,26 @@ export function showDataset(chartId, datasetIndex, dataIndex) {
     }
 }
 export function getLabels(chartId) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return [];
+    }
     const items = chart.options.plugins.legend.labels.generateLabels(chart);
     return items;
 }
 export function isDatasetVisible(chartId, datasetIndex) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return false;
+    }
     const isVisible = chart.isDatasetVisible(datasetIndex);
     return isVisible;
 }
 export function setDatasetPointsActive(chartId, datasetIndex) {
-    const chart = Chart.getChart(chartId);
+    const chart = getLiveChart(chartId);
+    if (!chart) {
+        return;
+    }
     if (chart.getActiveElements().length > 0) {
         chart.setActiveElements([]);
         chart.update();

--- a/tests/pax.BlazorChartJs.pwtests/DisposeTests.cs
+++ b/tests/pax.BlazorChartJs.pwtests/DisposeTests.cs
@@ -10,13 +10,31 @@ public class DisposeTests : PageTest
     [Test]
     public async Task DisposeTest()
     {
+        var rendererErrors = TrackRendererErrors();
+
         await Page.GotoAsync(Startup.GetSampleBaseUrl() + "/timeschart");
 
         // Expect a title "to contain" a substring.
         await Expect(Page).ToHaveTitleAsync(new Regex("TimesChart"), new Microsoft.Playwright.PageAssertionsToHaveTitleOptions() { Timeout = (float)Startup.WasmLoadDelay.TotalMilliseconds });
 
-        // Provoke ChartComponent.Dispose while initializing
-        // create a locator
+        var showChart = Page.GetByText("Show Chart", new Microsoft.Playwright.PageGetByTextOptions() { Exact = true });
+        await Expect(showChart).ToHaveAttributeAsync("type", "button");
+        await showChart.ClickAsync();
+
+        await Page.WaitForFunctionAsync(
+            @"() => {
+                const canvas = document.querySelector('canvas');
+                if (!canvas || typeof Chart === 'undefined') {
+                    return false;
+                }
+
+                const chart = Chart.getChart(canvas.id);
+                return chart?.options?.scales?.x?.type === 'time';
+            }",
+            null,
+            new Microsoft.Playwright.PageWaitForFunctionOptions { Timeout = (float)Startup.WasmLoadDelay.TotalMilliseconds });
+
+        // Provoke ChartComponent.Dispose after TimesChartComp initialized its JS module.
         var showAndDispose = Page.GetByText("ShowAndDispose Chart", new Microsoft.Playwright.PageGetByTextOptions() { Exact = true });
 
         // Expect an attribute "to be strictly equal" to the value.
@@ -36,6 +54,7 @@ public class DisposeTests : PageTest
 
         var error = Page.GetByText("An unhandled error has occurred.", new Microsoft.Playwright.PageGetByTextOptions() { Exact = false });
         await Expect(error).ToHaveCSSAsync("display", "none");
+        Assert.That(rendererErrors, Is.Empty, string.Join(Environment.NewLine, rendererErrors));
     }
 
     [Test]
@@ -68,5 +87,35 @@ public class DisposeTests : PageTest
 
         var error = Page.GetByText("An unhandled error has occurred.", new Microsoft.Playwright.PageGetByTextOptions() { Exact = false });
         await Expect(error).ToHaveCSSAsync("display", "none");
+    }
+
+    private List<string> TrackRendererErrors()
+    {
+        List<string> rendererErrors = [];
+
+        Page.Console += (_, message) =>
+        {
+            if (message.Type == "error" && IsRendererError(message.Text))
+            {
+                rendererErrors.Add(message.Text);
+            }
+        };
+
+        Page.PageError += (_, error) =>
+        {
+            if (IsRendererError(error))
+            {
+                rendererErrors.Add(error);
+            }
+        };
+
+        return rendererErrors;
+    }
+
+    private static bool IsRendererError(string message)
+    {
+        return message.Contains("Unhandled exception rendering component", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("Cannot wait on monitors", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("PlatformNotSupportedException", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/pax.BlazorChartJs.pwtests/DisposeTests.cs
+++ b/tests/pax.BlazorChartJs.pwtests/DisposeTests.cs
@@ -37,4 +37,37 @@ public class DisposeTests : PageTest
         var error = Page.GetByText("An unhandled error has occurred.", new Microsoft.Playwright.PageGetByTextOptions() { Exact = false });
         await Expect(error).ToHaveCSSAsync("display", "none");
     }
+
+    [Test]
+    public async Task DatasetInteropAfterDisposeIsIgnored()
+    {
+        await Page.GotoAsync(Startup.GetSampleBaseUrl() + "/linechart");
+        await Expect(Page).ToHaveTitleAsync(new Regex("LineChart"), new Microsoft.Playwright.PageAssertionsToHaveTitleOptions() { Timeout = (float)Startup.WasmLoadDelay.TotalMilliseconds });
+
+        var canvasId = await Page.Locator("canvas").GetAttributeAsync("id");
+        Assert.That(Guid.TryParse(canvasId, out _), Is.True);
+
+        var chartInteropVersion = await Page.EvaluateAsync<string>("() => window.chartJsInteropVersion ?? ''");
+        if (chartInteropVersion != "0.8.8")
+        {
+            Assert.Ignore($"The configured sample site is serving pax.BlazorChartJs {chartInteropVersion}; this regression requires 0.8.8.");
+        }
+
+        await Page.GotoAsync(Startup.GetSampleBaseUrl());
+
+        await Page.EvaluateAsync(
+            @"(chartId) => {
+                const chartInterop = window.ChartJsInterop;
+                const chart = typeof Chart === 'undefined' ? undefined : Chart.getChart(chartId);
+                const dataset = { id: 'disposed-test', label: 'Disposed Test', data: [1, 2, 3] };
+                chartInterop.addDatasets(chart, [dataset]);
+                chartInterop.updateDatasets(chart, [dataset]);
+                chartInterop.removeDatasets(chart, [dataset.id]);
+                chartInterop.setDatasets(chart, [dataset]);
+            }",
+            canvasId);
+
+        var error = Page.GetByText("An unhandled error has occurred.", new Microsoft.Playwright.PageGetByTextOptions() { Exact = false });
+        await Expect(error).ToHaveCSSAsync("display", "none");
+    }
 }

--- a/tests/pax.BlazorChartJs.pwtests/DisposeTests.cs
+++ b/tests/pax.BlazorChartJs.pwtests/DisposeTests.cs
@@ -56,14 +56,13 @@ public class DisposeTests : PageTest
         await Page.GotoAsync(Startup.GetSampleBaseUrl());
 
         await Page.EvaluateAsync(
-            @"(chartId) => {
-                const chartInterop = window.ChartJsInterop;
-                const chart = typeof Chart === 'undefined' ? undefined : Chart.getChart(chartId);
+            @"async (chartId) => {
+                const chartInterop = await import('./_content/pax.BlazorChartJs/chartJsInterop.js?v=0.8.8');
                 const dataset = { id: 'disposed-test', label: 'Disposed Test', data: [1, 2, 3] };
-                chartInterop.addDatasets(chart, [dataset]);
-                chartInterop.updateDatasets(chart, [dataset]);
-                chartInterop.removeDatasets(chart, [dataset.id]);
-                chartInterop.setDatasets(chart, [dataset]);
+                chartInterop.addDatasets(chartId, [dataset]);
+                chartInterop.updateDatasets(chartId, [dataset]);
+                chartInterop.removeDatasets(chartId, [dataset.id]);
+                chartInterop.setDatasets(chartId, [dataset]);
             }",
             canvasId);
 

--- a/tests/pax.BlazorChartJs.pwtests/Startup.cs
+++ b/tests/pax.BlazorChartJs.pwtests/Startup.cs
@@ -1,7 +1,6 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Playwright.NUnit;
-using System.Diagnostics;
 
 namespace PlaywrightTests;
 
@@ -17,10 +16,6 @@ public static class Startup
 
     private static string sampleBaseUrl = "";
 
-    private static readonly SemaphoreSlim ssStart = new(1, 1);
-    private static readonly SemaphoreSlim ssStop = new(1, 1);
-    private static int runners;
-    private static readonly TimeSpan delay = TimeSpan.FromMilliseconds(30000);
     private static readonly object lockobject = new();
 
     public static string GetSampleBaseUrl()
@@ -45,6 +40,10 @@ public static class Startup
             .Build();
 
         sampleBaseUrl = configuration["SampleBaseUrl"] ?? "";
+        if (String.IsNullOrWhiteSpace(sampleBaseUrl))
+        {
+            throw new InvalidOperationException("SampleBaseUrl must be configured for Playwright tests.");
+        }
 
         if (int.TryParse(configuration["WasmLoadDelay"], out int wasmMs))
         {
@@ -62,74 +61,18 @@ public static class Startup
         }
     }
 
-    public static async Task Init()
+    public static Task Init()
     {
-        await ssStart.WaitAsync();
-
-        try
-        {
-            runners++;
-
-            if (runners > 1)
-            {
-                return;
-            }
-
-            var processes = Process.GetProcessesByName("pax.BlazorChartJs.sample");
-            var sampleProcess = processes.FirstOrDefault();
-
-            if (sampleProcess != null)
-            {
-                StopSampleProject(sampleProcess);
-            }
-            await RunSampleProject();
-        }
-        finally
-        {
-            ssStart.Release();
-        }
-
+        // CI runs against the published GitHub Pages app from appsettings.json.
+        // Local runs use ASPNETCORE_ENVIRONMENT=Development after the host is
+        // started manually with the commands in tests/README.md.
+        GetSampleBaseUrl();
+        return Task.CompletedTask;
     }
 
-    public static async Task Stop()
+    public static Task Stop()
     {
-        await ssStop.WaitAsync();
-        try
-        {
-            runners--;
-
-            if (runners == 0)
-            {
-                var processes = Process.GetProcessesByName("pax.BlazorChartJs.sample");
-                var sampleProcess = processes.FirstOrDefault();
-
-                if (sampleProcess != null)
-                {
-                    StopSampleProject(sampleProcess);
-                }
-            }
-        }
-        finally
-        {
-            ssStop.Release();
-        }
-    }
-
-    private static void StopSampleProject(Process process)
-    {
-        process.Kill();
-    }
-
-    private static async Task RunSampleProject()
-    {
-        Process.Start(new ProcessStartInfo()
-        {
-            FileName = "dotnet",
-            Arguments = "run --project ../../../../../src/pax.BlazorChartJs.wasmsample"
-        });
-
-        // wait for dotnet
-        await Task.Delay(delay);
+        return Task.CompletedTask;
     }
 }
 


### PR DESCRIPTION
## Summary

- Bumps the library/package version to 0.8.8 and updates the sample library references.
- Hardens Chart.js interop and dataset handling around disposed charts/components.
- Refactors event/config utility code and sample components for the updated async disposal flow.
- Adds Playwright dispose coverage and simplifies the test startup setup.

## Why

The branch addresses add-dataset/update flows that could continue interacting with disposed chart instances. That behavior risks JavaScript interop failures and stale Chart.js state after component disposal.

## Impact

Consumers should get safer dataset operations when charts are torn down or recreated, with updated samples showing the intended disposal pattern.

## Validation

- `dotnet build pax.BlazorChartJs.sln` passed with 0 warnings and 0 errors.